### PR TITLE
DTR/DSR signal inversion fix

### DIFF
--- a/Project/dsman.tbh
+++ b/Project/dsman.tbh
@@ -28,7 +28,7 @@ enum en_dsman_status_codes
 	EN_DSMAN_STATUS_WRONG_DESCRIPTOR	'Wrong descriptor file data
 end enum
 
-const FIRMWARE_VERSION="{ds4.38}"
+const FIRMWARE_VERSION="{ds4.39}"
 const LOGIN_TOUT_CONST=600
 const MAX_NET_CMD_LEN=131 'max length of network command
 const MAX_NET_RPL_LEN=255 'max length of network replies

--- a/Project/main.tbs
+++ b/Project/main.tbs
@@ -429,7 +429,7 @@ init_now:			'already in the serial login mode -- this is init
 		if param_rm(f)<>RM_SERVER and param_cm(f)=CM_COMMAND_DSR then
 			sock.num=sock_comm(f)
 			io.num=dsr_mapping(f)
-			if io.state=LOW then
+			if io.state=HIGH then
 				'connection is supposed to be off
 				if sock.statesimple=PL_SSTS_EST then
 					sock.close
@@ -655,9 +655,9 @@ sub on_sock_event(newstate as pl_sock_state, newstatesimple as pl_sock_state_sim
 			if param_dt(f)=YES then
 				io.num=dtr_mapping(f)
 				if newstatesimple=PL_SSTS_EST then
-					io.state=HIGH
-				else
 					io.state=LOW
+				else
+					io.state=HIGH
 				end if
 			end if
 

--- a/Project/soi_application.tpr
+++ b/Project/soi_application.tpr
@@ -1,6 +1,6 @@
 [project]
 version=1
-platform=WS1102
+platform=DS1100
 src_lib_ver=2_01_05
 name=soi_application-4_38
 output=soi_application-4_38.tpc
@@ -183,6 +183,10 @@ address=156.101.249.54.90.98
 platform=WS1102
 transport=serial
 address=
+[address45]
+platform=DS1100
+transport=udp_broadcast
+address=0.36.119.83.3.81
 [file1]
 path=main.tbs
 type=basic


### PR DESCRIPTION
Bug:

DS1100 configured with

a) Connection mode: 3 - On command OR DSR=HIGH
b) DTR mode:  1- Indicate connection status

DTR/DSR signalling is inverted in the ds4.38 binary as tested on the DS1100

Detail:

The DS203 connects to the configured host when its DSR input reads high, and it indicates successful connection by asserting its DTR output. The DS203 disconnects to the configured host when its DSR input reads low, and it indicates it is no longer connected to the host by de-asserting its DTR output.

The DS1100 running ds4.38 is behaving exactly the opposite: The DS1100 connects to the configured host when its DSR input reads low, and it indicates successful connection by de-asserting its DTR output. The DS1100 disconnects to the configured host when its DSR input reads high, and it indicates it is no longer connected to the host by asserting its DTR output.

This behavior permeates to the floating signal state; when no device is attached to the DS1100 it thinks it should connect to its configured host.  This is the opposite of earlier DS203 behavior, and presents a compatibility problem with existing applications expecting the prior behavior of the DS203, requiring both that a device be connected with the SOI device and requesting a host connection (by asserting DTR) before the the DS1100 attempts to connect with the remote internet host.

This update restores the classic, expected behavior.

New Binary compiled as ds4.39